### PR TITLE
Fix OIDC publishing: add contents:read permission

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Build
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,10 +26,11 @@ jobs:
           npm i
           npm run build
 
-      - name: Remove token from .npmrc for OIDC auth
-        run: npm config delete //registry.npmjs.org/:_authToken --location user
-
-      - run: npm publish --access public
+      - name: Publish with OIDC
+        run: |
+          echo "registry=https://registry.npmjs.org/" > "$NPM_CONFIG_USERCONFIG"
+          unset NODE_AUTH_TOKEN
+          npm publish --access public
 
       - name: Get version
         id: version

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,11 +19,15 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Build
         run: |
           npm i
           npm run build
+
+      - name: Remove token from .npmrc for OIDC auth
+        run: npm config delete //registry.npmjs.org/:_authToken --location user
 
       - run: npm publish --access public
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   publish:
@@ -26,7 +27,7 @@ jobs:
           npm i
           npm run build
 
-      - run: npm publish --provenance --access public
+      - run: npm publish --access public
 
       - name: Get version
         id: version

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,11 +26,7 @@ jobs:
           npm i
           npm run build
 
-      - name: Publish with OIDC
-        run: |
-          echo "registry=https://registry.npmjs.org/" > "$NPM_CONFIG_USERCONFIG"
-          unset NODE_AUTH_TOKEN
-          npm publish --provenance --access public
+      - run: npm publish --provenance --access public
 
       - name: Get version
         id: version

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "registry=https://registry.npmjs.org/" > "$NPM_CONFIG_USERCONFIG"
           unset NODE_AUTH_TOKEN
-          npm publish --access public
+          npm publish --provenance --access public
 
       - name: Get version
         id: version


### PR DESCRIPTION
## Summary
- Adds missing `contents: read` permission alongside `id-token: write`
- Removes `--provenance` flag to match the official npmjs trusted publishing example
- Without `contents: read`, the OIDC flow fails silently with `ENEEDAUTH`

## Test plan
- [ ] Merge and push a new tag to trigger publish
- [ ] Verify npm publish succeeds via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)